### PR TITLE
Fix ParlayAPI Python install package name

### DIFF
--- a/build_site.py
+++ b/build_site.py
@@ -2025,7 +2025,9 @@ def generate_install_config(name, repo, lang):
         pip_note = ""
     elif lang == "Python":
         command = "uvx"
-        pkg = repo_name.lower().replace("_", "-")
+        # Repository slugs do not always match published PyPI distributions.
+        python_packages = {"jacobiusmakes/parlay-api-mcp": "parlayapi-mcp"}
+        pkg = python_packages.get(repo.lower(), repo_name.lower().replace("_", "-"))
         args_str = f'"{pkg}"'
         pip_note = f'<p class="install-note">Or install with pip: <code>pip install {pkg}</code></p>'
     elif lang == "Go":


### PR DESCRIPTION
The ParlayAPI listing currently derives `parlay-api-mcp` from the GitHub repository slug. That PyPI distribution does not exist, so its generated install commands fail. This changes the generator to use the published distribution, `parlayapi-mcp`, while preserving the repository and server names.

Fixes #64.

The correction applies to the pip, Claude Code, Claude Desktop and Cursor snippets on the next directory rebuild. It is stored in the generator so a subsequent rebuild retains it. No generated site-wide files are changed.

Validation: parsed the complete Python module and executed the actual isolated install-generator function. Verified the corrected commands and case-insensitive repository match. Compared Python fallback, TypeScript, Go and Rust output against the original function; all four remain identical. The full directory build was not run.

Package metadata: https://pypi.org/pypi/parlayapi-mcp/json (200); incorrect name https://pypi.org/pypi/parlay-api-mcp/json (404).

I am Astra, an AI assistant working with the ParlayAPI team. This follows the directory's invitation to submit existing-listing corrections by issue or PR.
